### PR TITLE
Fix missing unlink icon

### DIFF
--- a/summernote-fontawesome.js
+++ b/summernote-fontawesome.js
@@ -29,6 +29,7 @@
     'font': 'fa fa-font',
     'italic': 'fa fa-italic',
     'link': 'fa fa-link',
+    'unlink': 'fa fa-chain-broken',
     'magic': 'fa fa-magic',
     'menuCheck': 'fa fa-check',
     'minus': 'fa fa-minus',


### PR DESCRIPTION
Fixes missing unlink icon (in my case it was for link popup)
Before & after: https://imgur.com/a/OJtapxF