### PR TITLE
Fix redo icon

### DIFF
--- a/summernote-fontawesome.js
+++ b/summernote-fontawesome.js
@@ -37,7 +37,7 @@
     'pencil': 'fa fa-pencil',
     'picture': 'fa fa-picture-o',
     'question': 'fa fa-question',
-    'redo': 'fa fa-redo',
+    'redo': 'fa fa-repeat',
     'square': 'fa fa-square',
     'strikethrough': 'fa fa-strikethrough',
     'subscript': 'fa fa-subscript',


### PR DESCRIPTION
There is no fa-redo icon in font-awesome 4.7. There is fa-repeat tho, which is an opposite to undo icon:
https://fontawesome.com/v4.7.0/icon/undo
https://fontawesome.com/v4.7.0/icon/repeat